### PR TITLE
Refactor export/import logic

### DIFF
--- a/releasenotes/notes/refactor-export-import-49bbf0e8a364f139.yaml
+++ b/releasenotes/notes/refactor-export-import-49bbf0e8a364f139.yaml
@@ -1,0 +1,8 @@
+---
+
+other:
+  - |
+    Each markdown file written during the course export
+    is no longer accompanied by an xml file with XBlock attributes.
+    The XBlock attributes are now included in the markdown node,
+    defined in a vertical block.


### PR DESCRIPTION
Refactor the logic for course export/import so that we loose the
unneccessary extra xml file in the markdown folder that corresponds
to each markdown file. Add the neccessary attributes to the
markdown node defined in a vertical block.