### PR TITLE
Update safe mode

### DIFF
--- a/.github/workflow/tox.yml
+++ b/.github/workflow/tox.yml
@@ -1,0 +1,67 @@
+name: Python package
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - 3.5
+          - 3.8
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install tox tox-gh-actions tox-pip-version 'setuptools_scm<6'
+    - name: Test with tox
+      env:
+        TOX_PIP_VERSION: '20.2.4'
+      run: tox
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage-${{ matrix.python-version }}
+        path: .coverage*
+        retention-days: 1
+
+  report:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v1
+    - name: Download artifacts
+      uses: actions/download-artifact@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        pip install coverage
+    - name: Compile coverage data
+      run: |
+        mv coverage-*/.coverage* .
+        coverage combine
+        coverage html
+        coverage xml
+        coverage report
+    - name: Upload htmlcov archive
+      uses: actions/upload-artifact@v2
+      with:
+        name: htmlcov
+        path: htmlcov
+        retention-days: 7
+    - name: Upload to codecov
+      uses: codecov/codecov-action@v1

--- a/README.md
+++ b/README.md
@@ -45,7 +45,14 @@ by default the following extras are included:
 It is possible to configure more [extras](https://github.com/trentm/python-markdown2/wiki/Extras), by adding to the extras list under `"markdown"` key in `XBLOCK_SETTINGS`
 at `/edx/etc/{studio|lms}.yml`
 
-By default, the `safe_mode` for `markdown2` library is enabled, which means that writing inline HTML is not allowed and if written, all tags will be replaced with `[HTML_REMOVED]`. To disable this setting and allow inline HTML, you'll need to set the `safe_mode` to `False` in `XBLOCK_SETTINGS`.
+By default, the `safe_mode` for `markdown2` library is enabled and set
+to `replace`, which means that writing inline HTML is not allowed and
+if written, all tags will be replaced with `[HTML_REMOVED]`. You can
+also set `safe_mode` to `escape`, which only replaces `<`, `>` and `&`
+with `&lt;`, `&gt;` and `&amp;`. To disable safe mode altogether and
+allow inline HTML, you'll need to set `safe_mode` to `False` or `None`
+in `XBLOCK_SETTINGS`. Please note that setting `safe_mode` to the
+empty string (`''`) *also* disables safe mode.
 
 Example:
 ```
@@ -64,7 +71,7 @@ XBLOCK_SETTINGS:
             - use-file-vars
             - wiki-tables
             - tag-friendly
-        safe_mode: True
+        safe_mode: replace
 ```
 
 ## Development

--- a/markdown_xblock/html.py
+++ b/markdown_xblock/html.py
@@ -29,7 +29,7 @@ DEFAULT_EXTRAS = [
 ]
 DEFAULT_SETTINGS = {
     "extras": DEFAULT_EXTRAS,
-    "safe_mode": True
+    "safe_mode": 'replace'
 }
 
 
@@ -231,8 +231,10 @@ class MarkdownXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock)
         A property that returns the markdown content data as html.
         """
         settings = get_xblock_settings()
-        extras = settings.get("extras", DEFAULT_EXTRAS)
-        safe_mode = settings.get("safe_mode", True)
+        extras = settings.get("extras",
+                              DEFAULT_SETTINGS['extras'])
+        safe_mode = settings.get("safe_mode",
+                                 DEFAULT_SETTINGS['safe_mode'])
 
         html = markdown2.markdown(
             self.data,

--- a/releasenotes/notes/safe_mode_replace_escape-40fdb78ec8aa5eff.yaml
+++ b/releasenotes/notes/safe_mode_replace_escape-40fdb78ec8aa5eff.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    The XBlock settings now support the string values "replace" and "escape"
+    for safe_mode, just like the upstream Markdown2 library does. A Boolean
+    value of True is considered to be equivalent to "replace". A value of
+    False, None, or the empty string disables safe mode.


### PR DESCRIPTION
In Markdown2, `safe_mode` is actually a string, currently supporting the values `replace` and `escape`. Support for the Boolean value is only maintained for compatibility with Markdown, a Boolean value of `True` is equivalent to `replace`.
    
Retain the default of `replace`, but add the ability to also set `escape`. Also, interpret `True` as equivalent to 'replace', and `False` or `None` (and the empty string) to mean to disable safe mode.
    
Add test cases for all of the above. Also, add a GitHub Actions workflow.
