### PR TITLE
Render XBlock when in read-only mode

### DIFF
--- a/markdown_xblock/html.py
+++ b/markdown_xblock/html.py
@@ -70,6 +70,7 @@ class MarkdownXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock)
     )
     editor = 'markdown'
     editable_fields = ('display_name', 'classes')
+    show_in_read_only_mode = True
 
     @staticmethod
     def resource_string(path):


### PR DESCRIPTION
Unless explicity allowed, XBlocks by default do not render in the LMS when in read-only mode (which is active when a course Staff user masquerades as a specific learner, as in _View this course as → Specific learner_).

Set the XBlock's `show_in_read_only_mode` attribute to `True`, so it renders in read-only mode.