### PR TITLE
Update README, add a reno for the safe mode fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ by default the following extras are included:
 * "tables"
 * "use-file-vars"
 
-It is possible to configure more [extras](https://github.com/trentm/python-markdown2/wiki/Extras), by adding to the extras list under `"markdown"` key in `XBLOCK_SETTINGS`
+## Configuration
+It is possible to configure more
+[extras](https://github.com/trentm/python-markdown2/wiki/Extras), by
+adding to the extras list under `"markdown"` key in `XBLOCK_SETTINGS`
 at `/edx/etc/{studio|lms}.yml`
 
 By default, the `safe_mode` for `markdown2` library is enabled and set
@@ -72,6 +75,45 @@ XBLOCK_SETTINGS:
             - wiki-tables
             - tag-friendly
         safe_mode: replace
+```
+
+## Usage notes
+
+### Images
+
+To include images in your markdown content, use the standard
+Markdown inline image syntax. Your course images will normally live in
+the `static/images` directory, relative to the root of your course, so
+you would include an image like this:
+
+```markdown
+![alt text for example image](/static/images/example.png)
+```
+
+The XBlock will then mangle your image reference into a static asset
+reference.
+
+### Links
+
+If Markdown XBlock content contains links to another course, and your
+platform is configured with the XBlock's safe mode enabled, a link
+like
+
+```markdown
+[link text](https://example.com/courses/course-v1:Org+Class+Version/about)
+```
+
+will, when rendered, turn its `+` characters into whitespace. That
+isn't actually wrong, because both `+` and the `%20` escape sequence
+in URLs are meant to represent whitespace, yet Open edX uses the `+`
+character to mean something *other* than whitespace, and that's a bit
+of a problem.
+
+To preserve Open edX course URL references, please explicitly encode
+the `+` character as `%2B`, like so:
+
+```markdown
+[link text](https://example.com/courses/course-v1:Org%2BClass%2BVersion/about)
 ```
 
 ## Development

--- a/releasenotes/notes/show_in_read_only_mode-3af39459d5d56b33.yaml
+++ b/releasenotes/notes/show_in_read_only_mode-3af39459d5d56b33.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The XBlock now renders normally in "read-only" ("masquerading")
+    mode, which applies when a course instructor (a user with either
+    per-course or platform-wide Staff permissions) selects the "View
+    this course as" → "Specific learner" option in the Open edX LMS.


### PR DESCRIPTION
Documentation update:

* Mention links and images in `README.md`.
* Add the `show_in_read_only_mode` fix from https://github.com/citynetwork/markdown-xblock/pull/17 to the release notes.