### PR TITLE
Remove Python 3.5 from tox and GitLab CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,17 +2,6 @@ stages:
   - build
   - report
 
-py35:
-  image: python:3.5
-  stage: build
-  script:
-    - pip install tox
-    - tox -e py35,flake8
-  artifacts:
-    paths:
-      - .coverage*
-    expire_in: 5 minutes
-
 py38:
   image: python:3.8
   stage: build

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pip install git+https://github.com/citynetwork/markdown-xblock.git
 
 You may specify the `-e` flag if you intend to develop on the repo.
 
-The minimum supported Python version is 3.5.
+The minimum supported Python version is 3.8.
 
 To enable this block, add `"markdown"` to the course's advanced module list. 
 The option `Markdown` will appear in the advanced components.

--- a/releasenotes/notes/remove_py35-0b265861449b1753.yaml
+++ b/releasenotes/notes/remove_py35-0b265861449b1753.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - |
+    This release removes support for Python 3.5. Do not upgrade to
+    this release on platforms still using Python 3.5.
+deprecations:
+  - |
+    With this release, all automated testing on Python 3.5 has been
+    removed, and Python 3.8 is the recommended Python release.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,38},flake8,report
+envlist = py38,flake8,report
 
 [gh-actions]
 python =


### PR DESCRIPTION
Apply the same logic as in 839abff269897c9a653ff3809ab1c6af30107213: we're still able to test locally with Python 3.5 (with `tox -e py35`, using built-in tox virtualenv patterns[1]), but we really don't want to block on changes that break only on that release anymore.

Also, update the README to say that 3.8 is the minimum Python version required.

Reference:
[1]: https://tox.readthedocs.io/en/latest/example/basic.html