### PR TITLE
Add some CSS to tables

### DIFF
--- a/markdown_xblock/html.py
+++ b/markdown_xblock/html.py
@@ -90,6 +90,7 @@ class MarkdownXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock)
         frag.add_javascript(self.resource_string('public/plugins/codesample/js/prism.js'))
 
         frag.add_css(self.resource_string('static/css/pygments.css'))
+        frag.add_css(self.resource_string('static/css/html.css'))
 
         return frag
 

--- a/markdown_xblock/static/css/html.css
+++ b/markdown_xblock/static/css/html.css
@@ -42,3 +42,19 @@
 .tabcontent {
     display: none;
 }
+
+.markdown_xblock table {
+    width: 100%;
+    margin: 20px 0;
+    border-collapse: collapse;
+    font-size: 16px;
+}
+.markdown_xblock th, td {
+    padding: 10px;
+    border: 1px solid #c8c8c8;
+    font-size: 14px;
+}
+.markdown_xblock th {
+    background: #eee;
+    font-weight: bold;
+}


### PR DESCRIPTION
When using the "tables" extra feature (enabled by default) tables
are created perfectly fine but no styling is added to the tables
by default.

While the tables can be styled/themed via theme/brand setups as they are,
not everyone using this XBlock may have access to these settings.

Add some CSS to match the tables to the current raw-HTML XBlock tables
to create a better and more cohesive user experience.