### PR TITLE
Prepare 1.1.1 release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,12 @@
+[bumpversion]
+commit = True
+tag = True
+current_version = 1.1.0
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<rc>\d+))?
+serialize =
+	{major}.{minor}.{patch}rc{rc}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:rc]
+
+[bumpversion:file:README.md]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,9 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 1.1.0
+current_version = 1.1.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<rc>\d+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}rc{rc}
 	{major}.{minor}.{patch}
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -33,3 +33,35 @@ on every push to GitHub.
 *If you absolutely must,* you can use the `--no-verify` flag to `git
 commit` and `git push` to bypass local checks, and rely on GitHub
 Actions alone. But doing so is strongly discouraged.
+
+
+How to cut a release
+--------------------
+
+This repository uses
+[bump2version](https://pypi.org/project/bump2version/) (the maintained
+fork of [bumpversion](https://github.com/peritus/bumpversion)) for
+managing new releases.
+
+Use `tox -e bumpversion` to increase the version number:
+
+-   `tox -e bumpversion patch`: creates a new point release (such as 1.1.1)
+-   `tox -e bumpversion minor`: creates a new minor release, with the patch level set to 0 (such as 1.2.0)
+-   `tox -e bumpversion major`: creates a new major release, with the minor and patch levels set to 0 (such as 2.0.0)
+
+This creates a new commit, and also a new tag, named `v<num>`, where
+`<num>` is the new version number.
+
+Push these two commits (the one for the changelog, and the version
+bump) to `origin`. Make sure you push the `v<num>` tag to `origin` as
+well.
+
+Then, build a new `sdist` package, and [upload it to
+PyPI](https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives)
+(with [twine](https://packaging.python.org/key_projects/#twine)):
+
+```bash
+rm dist/* -f
+./setup.py sdist
+twine upload dist/*
+```

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ and displays it as HTML.
 You may install the markdown-xblock using its setup.py, or if you prefer to use pip, run:
 
 ```shell
-pip install markdown-xblock
+pip install markdown-xblock==1.1.0
 ```
 
 If you prefer to install directly from Git, run:
 
 ```shell
-pip install git+https://github.com/citynetwork/markdown-xblock.git
+pip install git+https://github.com/citynetwork/markdown-xblock.git@v1.1.0
 ```
 
 You may specify the `-e` flag if you intend to develop on the repo.

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ and displays it as HTML.
 You may install the markdown-xblock using its setup.py, or if you prefer to use pip, run:
 
 ```shell
-pip install markdown-xblock==1.1.0
+pip install markdown-xblock==1.1.1
 ```
 
 If you prefer to install directly from Git, run:
 
 ```shell
-pip install git+https://github.com/citynetwork/markdown-xblock.git@v1.1.0
+pip install git+https://github.com/citynetwork/markdown-xblock.git@v1.1.1
 ```
 
 You may specify the `-e` flag if you intend to develop on the repo.

--- a/tox.ini
+++ b/tox.ini
@@ -40,3 +40,16 @@ commands =
     coverage combine
     coverage report
     coverage html
+
+[testenv:bumpversion]
+skip_install = True
+passenv =
+  # Git can only find its global configuration if it knows where the
+  # user's HOME is.
+  HOME
+  # We set sign_tags in .bumpversion.cfg, so pass in the GnuPG agent
+  # reference to avoid having to retype the passphrase for an
+  # already-cached private key.
+  GPG_AGENT_INFO
+deps = bump2version
+commands = bump2version {posargs}


### PR DESCRIPTION
* Enable tagging with `tox -e bumpversion`
* Update `HACKING.md` and `README.md`
* Cut 1.1.1 release