### PR TITLE
Add support for public courses

### DIFF
--- a/markdown_xblock/html.py
+++ b/markdown_xblock/html.py
@@ -120,6 +120,13 @@ class MarkdownXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock)
 
         return frag
 
+    @XBlock.supports("multi_device")
+    def public_view(self, context=None):
+        """
+        Return the student_view when course is set to be public.
+        """
+        return self.student_view(context)
+
     @XBlock.json_handler
     def update_content(self, data, suffix=''):  # pylint: disable=unused-argument
         """

--- a/releasenotes/notes/add_public_view-d24763b7941dc2b0.yaml
+++ b/releasenotes/notes/add_public_view-d24763b7941dc2b0.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    The XBlock can now also be used in a public course.

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -31,6 +31,19 @@ class TestMarkdownXBlock(unittest.TestCase):
         fragment = block.student_view()
         self.assertIn('<div class="markdown_xblock"><h1>This is h1</h1>\n</div>\n', fragment.content)
 
+    def test_public_view(self):
+        """
+        Test public view rendering.
+        """
+        field_data = DictFieldData({'data': '# This is h1'})
+        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, None)
+        student_view_fragment = block.student_view()
+        self.assertIn('<div class="markdown_xblock"><h1>This is h1</h1>\n</div>\n',
+                      student_view_fragment.content)
+        public_view_fragment = block.public_view()
+        self.assertIn('<div class="markdown_xblock"><h1>This is h1</h1>\n</div>\n',
+                      public_view_fragment.content)
+
     def test_render_default_settings(self):
         """
         Test a basic rendering with default settings.


### PR DESCRIPTION
This XBlock is meant for creating text content in courses and there
is no reason it should be limited to enrolled students only when
course authors choose to make their course public.

Add implemention for the `public_view` to allow using this XBlock
in public courses.