### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,7 +10,14 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.8
+          - '3.8'
+          - '3.10'
+        pip-version:
+          - 22.0.4
+          - 23.2.1
+        include:
+          - python-version: '3.12'
+            pip-version: '23.2.1'
 
     steps:
     - name: Check out code
@@ -21,10 +28,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install "tox<4" tox-gh-actions tox-pip-version 'setuptools_scm<6'
-    - name: Test with tox
+        pip install "tox<4" tox-gh-actions tox-pip-version 'setuptools_scm'
+    - name: Test with tox (pip ${{ matrix.pip-version }})
       env:
-        TOX_PIP_VERSION: '20.2.4'
+        TOX_PIP_VERSION: ${{ matrix.pip-version }}
       run: tox
     - name: Upload coverage data
       uses: actions/upload-artifact@v2

--- a/markdown_xblock/html.py
+++ b/markdown_xblock/html.py
@@ -5,7 +5,6 @@ import os
 
 import markdown2
 from path import Path as path
-import pkg_resources
 from django.conf import settings as django_settings
 from xblock.core import XBlock
 from xblock.fields import List, Scope, String
@@ -72,12 +71,6 @@ class MarkdownXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock)
     editable_fields = ('display_name', 'classes')
     show_in_read_only_mode = True
 
-    @staticmethod
-    def resource_string(path):
-        """Handy helper for getting resources from our kit."""
-        data = pkg_resources.resource_string(__name__, path)
-        return data.decode('utf8')
-
     @XBlock.supports('multi_device')
     def student_view(self, context=None):  # pylint: disable=unused-argument
         """
@@ -86,11 +79,11 @@ class MarkdownXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock)
         frag = Fragment()
         frag.content = xblock_loader.render_django_template('static/html/lms.html', {'self': self})
 
-        frag.add_css(self.resource_string('public/plugins/codesample/css/prism.css'))
-        frag.add_javascript(self.resource_string('public/plugins/codesample/js/prism.js'))
+        frag.add_css_url(self.runtime.local_resource_url(self, 'public/plugins/codesample/css/prism.css'))
+        frag.add_javascript_url(self.runtime.local_resource_url(self, 'public/plugins/codesample/js/prism.js'))
 
-        frag.add_css(self.resource_string('static/css/pygments.css'))
-        frag.add_css(self.resource_string('static/css/html.css'))
+        frag.add_css_url(self.runtime.local_resource_url(self, 'static/css/pygments.css'))
+        frag.add_css_url(self.runtime.local_resource_url(self, 'static/css/html.css'))
 
         return frag
 
@@ -167,24 +160,25 @@ class MarkdownXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock)
         A helper method to add all necessary styles to the fragment.
         :param frag: The fragment that will hold the scripts.
         """
-        frag.add_css(self.resource_string('static/css/html.css'))
+        frag.add_css_url(self.runtime.local_resource_url(self, 'static/css/html.css'))
 
-        frag.add_css(self.resource_string('public/plugins/codemirror/codemirror-4.8/lib/codemirror.css'))
+        frag.add_css_url(self.runtime.local_resource_url(
+            self, 'public/plugins/codemirror/codemirror-4.8/lib/codemirror.css'))
 
     def add_scripts(self, frag):
         """
         A helper method to add all necessary scripts to the fragment.
         :param frag: The fragment that will hold the scripts.
         """
-        frag.add_javascript(self.resource_string('static/js/tinymce/tinymce.min.js'))
-        frag.add_javascript(self.resource_string('static/js/tinymce/themes/modern/theme.min.js'))
-        frag.add_javascript(self.resource_string('static/js/html.js'))
+        frag.add_javascript_url(self.runtime.local_resource_url(self, 'static/js/tinymce/tinymce.min.js'))
+        frag.add_javascript_url(self.runtime.local_resource_url(self, 'static/js/tinymce/themes/modern/theme.min.js'))
+        frag.add_javascript_url(self.runtime.local_resource_url(self, 'static/js/html.js'))
         frag.add_javascript(loader.load_unicode('public/studio_edit.js'))
 
         code_mirror_dir = 'public/plugins/codemirror/codemirror-4.8/'
 
-        frag.add_javascript(self.resource_string(code_mirror_dir + 'lib/codemirror.js'))
-        frag.add_javascript(self.resource_string(code_mirror_dir + 'mode/markdown/markdown.js'))
+        frag.add_javascript_url(self.runtime.local_resource_url(self, code_mirror_dir + 'lib/codemirror.js'))
+        frag.add_javascript_url(self.runtime.local_resource_url(self, code_mirror_dir + 'mode/markdown/markdown.js'))
 
     def get_editor_plugins(self):
         """

--- a/releasenotes/notes/python-3.12-support-dac839f8d01ac6b9.yaml
+++ b/releasenotes/notes/python-3.12-support-dac839f8d01ac6b9.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add support for Python 3.12

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,7 @@
 # Requirements for app run
 
 xblock-utils<=4.0.0
+xblock-sdk<0.9.0
 django-statici18n<2.5
 edx-i18n-tools<1.4
 Mako==1.2.4

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,4 +11,4 @@ mock==3.0.5
 
 # Github requirements
 django-pyfs<3.2
-xblock-sdk
+xblock-sdk<0.9.0

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'markdown_xblock',
     ],
     install_requires=[
-        'XBlock',
+        'XBlock<=1.9',
         'markdown2>=2.3.9',
         'Pygments>=2.0.1'
     ],

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -6,8 +6,9 @@ from __future__ import print_function
 import unittest
 
 from mock import Mock, patch
+from workbench.runtime import WorkbenchRuntime
 from xblock.field_data import DictFieldData
-from xblock.test.tools import TestRuntime
+from xblock.fields import ScopeIds
 
 from markdown2 import MarkdownError
 
@@ -20,14 +21,19 @@ class TestMarkdownXBlock(unittest.TestCase):
     Unit tests for `markdown_xblock`
     """
     def setUp(self):
-        self.runtime = TestRuntime()
+        block_type = 'markdown'
+        self.runtime = WorkbenchRuntime()
+        def_id = self.runtime.id_generator.create_definition(block_type)
+        usage_id = self.runtime.id_generator.create_usage(def_id)
+
+        self.scope_ids = ScopeIds('user', block_type, def_id, usage_id)
 
     def test_render(self):
         """
         Test a basic rendering with default settings.
         """
         field_data = DictFieldData({'data': '# This is h1'})
-        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, None)
+        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, scope_ids=self.scope_ids)
         fragment = block.student_view()
         self.assertIn('<div class="markdown_xblock"><h1>This is h1</h1>\n</div>\n', fragment.content)
 
@@ -36,7 +42,7 @@ class TestMarkdownXBlock(unittest.TestCase):
         Test public view rendering.
         """
         field_data = DictFieldData({'data': '# This is h1'})
-        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, None)
+        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, scope_ids=self.scope_ids)
         student_view_fragment = block.student_view()
         self.assertIn('<div class="markdown_xblock"><h1>This is h1</h1>\n</div>\n',
                       student_view_fragment.content)
@@ -54,7 +60,7 @@ class TestMarkdownXBlock(unittest.TestCase):
         longer interpreted as HTML).
         """
         field_data = DictFieldData({'data': '<h1>This is h1</h1>'})
-        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, None)
+        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, scope_ids=self.scope_ids)
         fragment = block.student_view()
         self.assertIn(
             '<div class="markdown_xblock"><p>[HTML_REMOVED]This is h1[HTML_REMOVED]</p>\n</div>\n',
@@ -69,7 +75,7 @@ class TestMarkdownXBlock(unittest.TestCase):
         one of 'replace', 'escape', True or False.
         """
         field_data = DictFieldData({'data': '<h1>This is h1</h1>'})
-        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, None)
+        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, scope_ids=self.scope_ids)
         settings = {
             "extras": DEFAULT_EXTRAS,
             "safe_mode": 'this is an invalid safe mode'
@@ -89,7 +95,7 @@ class TestMarkdownXBlock(unittest.TestCase):
         longer interpreted as HTML).
         """
         field_data = DictFieldData({'data': '<h1>This is h1</h1>'})
-        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, None)
+        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, scope_ids=self.scope_ids)
         settings = {
             "extras": DEFAULT_EXTRAS,
             "safe_mode": 'replace'
@@ -112,7 +118,7 @@ class TestMarkdownXBlock(unittest.TestCase):
         longer interpreted as HTML).
         """
         field_data = DictFieldData({'data': '<h1>This is h1</h1>'})
-        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, None)
+        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, scope_ids=self.scope_ids)
         settings = {
             "extras": DEFAULT_EXTRAS,
             "safe_mode": True
@@ -134,7 +140,7 @@ class TestMarkdownXBlock(unittest.TestCase):
         no longer interpreted as HTML).
         """
         field_data = DictFieldData({'data': '<h1>This is h1</h1>'})
-        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, None)
+        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, scope_ids=self.scope_ids)
         settings = {
             "extras": DEFAULT_EXTRAS,
             "safe_mode": 'escape'
@@ -153,7 +159,7 @@ class TestMarkdownXBlock(unittest.TestCase):
         Expects the content *not* to be sanitized.
         """
         field_data = DictFieldData({'data': '<h1>This is h1</h1>'})
-        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, None)
+        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, scope_ids=self.scope_ids)
         settings = {
             "extras": DEFAULT_EXTRAS,
             "safe_mode": False
@@ -171,7 +177,7 @@ class TestMarkdownXBlock(unittest.TestCase):
         field_data = DictFieldData(
             {'data': '[test1](https://test.com/courses/course-v1:Org+Class+Version/about) [test2](https://test.com/courses/course-v1%3AOrg%2BClass%2BVersion/about)'}  # noqa: E501
         )
-        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, None)
+        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, scope_ids=self.scope_ids)
         settings = {
             "extras": DEFAULT_EXTRAS,
             "safe_mode": 'replace'
@@ -196,7 +202,7 @@ class TestMarkdownXBlock(unittest.TestCase):
         field_data = DictFieldData(
             {'data': '[test1](https://test.com/courses/course-v1:Org+Class+Version/about) [test2](https://test.com/courses/course-v1%3AOrg%2BClass%2BVersion/about)'}  # noqa: E501
         )
-        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, None)
+        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, scope_ids=self.scope_ids)
         settings = {
             "extras": DEFAULT_EXTRAS,
             "safe_mode": 'escape'
@@ -221,7 +227,7 @@ class TestMarkdownXBlock(unittest.TestCase):
         field_data = DictFieldData(
             {'data': '[test](https://test.com/courses/course-v1:Org+Class+Version/about)'}
         )
-        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, None)
+        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, scope_ids=self.scope_ids)
         settings = {
             "extras": DEFAULT_EXTRAS,
             "safe_mode": False
@@ -239,7 +245,7 @@ class TestMarkdownXBlock(unittest.TestCase):
         Test that the substitution is not performed when `system` is not present inside XBlock.
         """
         field_data = DictFieldData({'data': '%%USER_ID%% %%COURSE_ID%%'})
-        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, None)
+        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, scope_ids=self.scope_ids)
         fragment = block.student_view()
         self.assertIn('<div class="markdown_xblock"><p>%%USER_ID%% %%COURSE_ID%%</p>\n</div>\n', fragment.content)
 
@@ -248,7 +254,7 @@ class TestMarkdownXBlock(unittest.TestCase):
         Test that the keywords are not replaced when they're not found.
         """
         field_data = DictFieldData({'data': 'USER_ID%% %%COURSE_ID%%'})
-        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, None)
+        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, scope_ids=self.scope_ids)
         block.system = Mock(anonymous_student_id=None)
         fragment = block.student_view()
         self.assertIn('<div class="markdown_xblock"><p>USER_ID%% %%COURSE_ID%%</p>\n</div>\n', fragment.content)
@@ -258,7 +264,7 @@ class TestMarkdownXBlock(unittest.TestCase):
         Test replacing %%USER_ID%% with anonymous user ID.
         """
         field_data = DictFieldData({'data': '%%USER_ID%%'})
-        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, None)
+        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, scope_ids=self.scope_ids)
         block.system = Mock(anonymous_student_id='test_user')
         fragment = block.student_view()
         self.assertIn('<div class="markdown_xblock"><p>test_user</p>\n</div>\n', fragment.content)
@@ -268,7 +274,7 @@ class TestMarkdownXBlock(unittest.TestCase):
         Test replacing %%COURSE_ID%% with HTML representation of course key.
         """
         field_data = DictFieldData({'data': '%%COURSE_ID%%'})
-        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, None)
+        block = markdown_xblock.MarkdownXBlock(self.runtime, field_data, scope_ids=self.scope_ids)
         course_locator_mock = Mock()
         course_locator_mock.html_id = Mock(return_value='test_course')
         block.system = Mock(course_id=course_locator_mock)

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
-envlist = py38,flake8,report
+envlist = py{38,310,312},flake8,report
 
 [gh-actions]
 python =
     3.8: py38,flake8
+    3.10: py310,flake8
+    3.12: py312,flake8
 
 [flake8]
 ignore = E124


### PR DESCRIPTION
* Expand the test matrix to include Python 3.10 / 3.12 and pip 22.0.4 / 23.2.1
* Replace the use of 'pkg_resources' to locate resource files with 'local_resource_url' from `XBlock.Runtime` and update the tests accordingly.

Additionally:
* Add upper constraints to XBlock and xblock-sdk as newer versions include breaking changes (that doesn't make sense for us to implement before they will be included in an Open edX release).