### PR TITLE
Add support for Open edX Redwood release

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         python-version:
           - '3.8'
-          - '3.10'
           - '3.11'
         pip-version:
           - 22.0.4

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -12,6 +12,7 @@ jobs:
         python-version:
           - '3.8'
           - '3.10'
+          - '3.11'
         pip-version:
           - 22.0.4
           - 23.2.1

--- a/markdown_xblock/html.py
+++ b/markdown_xblock/html.py
@@ -8,10 +8,16 @@ from path import Path as path
 from django.conf import settings as django_settings
 from xblock.core import XBlock
 from xblock.fields import List, Scope, String
-from xblock.fragment import Fragment
-from xblockutils.resources import ResourceLoader
-from xblockutils.settings import XBlockWithSettingsMixin
-from xblockutils.studio_editable import StudioEditableXBlockMixin, loader
+try:  # XBlock 2+
+    from web_fragments.fragment import Fragment
+    from xblock.utils.resources import ResourceLoader
+    from xblock.utils.settings import XBlockWithSettingsMixin
+    from xblock.utils.studio_editable import StudioEditableXBlockMixin, loader
+except ImportError:  # Compatibility with XBlock<2
+    from xblock.fragment import Fragment
+    from xblockutils.resources import ResourceLoader
+    from xblockutils.settings import XBlockWithSettingsMixin
+    from xblockutils.studio_editable import StudioEditableXBlockMixin, loader
 
 from .utils import _
 
@@ -276,11 +282,21 @@ class MarkdownXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock)
         return fields
 
     @classmethod
-    def parse_xml(cls, node, runtime, keys, id_generator):
+    def parse_xml(cls, node, runtime, keys, id_generator=None):
         """
         Use `node` to construct a new block.
         """
         block = runtime.construct_xblock_from_class(cls, keys)
+
+        # Prior to XBlock 2.0, id_generator is passed in.
+        # Since XBlock 2.0, we grab it from the runtime.
+        #
+        # TODO: Once we decide to drop support for versions prior to
+        # XBlock 2 (i.e. Open edX releases before Redwood), we can
+        # drop id_generator from the method signature, and always rely
+        # on runtime.id_generator.
+        if not id_generator:
+            id_generator = runtime.id_generator
 
         # Read markdown content from file and add to editor.
         url_name = node.get('url_name', node.get('slug'))

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,6 @@
 # Requirements for app run
 
-xblock-utils<=4.0.0
-xblock-sdk<0.9.0
+xblock-sdk
 django-statici18n<2.5
 edx-i18n-tools<1.4
 Mako==1.2.4

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,4 +11,5 @@ mock==3.0.5
 
 # Github requirements
 django-pyfs<3.2
-xblock-sdk<0.9.0
+xblock-sdk<0.9.0;python_version<"3.9"
+xblock-sdk;python_version>="3.9"

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,10 @@ setup(
         'markdown_xblock',
     ],
     install_requires=[
-        'XBlock<=1.9',
+        'XBlock<2; python_version < "3.9"',
+        'XBlock<5; python_version >= "3.9"',
         'markdown2>=2.3.9',
-        'Pygments>=2.0.1'
+        'Pygments>=2.0.1',
     ],
     setup_requires=[
         'setuptools-scm',

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py{38,310,312},flake8,report
+envlist = py{38,310,311,312},flake8,report
 
 [gh-actions]
 python =
     3.8: py38,flake8
     3.10: py310,flake8
+    3.11: py311,flake8
     3.12: py312,flake8
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py{38,310,311,312},pipdeptree{,-requirements},flake8,report
+envlist = py{38,311,312},pipdeptree{,-requirements},flake8,report
 
 [gh-actions]
 python =
     3.8: py38,pipdeptree{,-requirements},flake8
-    3.10: py310,pipdeptree{,-requirements},flake8
     3.11: py311,pipdeptree{,-requirements},flake8
     3.12: py312,pipdeptree{,-requirements},flake8
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py{38,310,311,312},flake8,report
+envlist = py{38,310,311,312},pipdeptree{,-requirements},flake8,report
 
 [gh-actions]
 python =
-    3.8: py38,flake8
-    3.10: py310,flake8
-    3.11: py311,flake8
-    3.12: py312,flake8
+    3.8: py38,pipdeptree{,-requirements},flake8
+    3.10: py310,pipdeptree{,-requirements},flake8
+    3.11: py311,pipdeptree{,-requirements},flake8
+    3.12: py312,pipdeptree{,-requirements},flake8
 
 [flake8]
 ignore = E124
@@ -27,6 +27,17 @@ passenv = DJANGO_*
 deps =
      -rrequirements/base.txt
      -rrequirements/test.txt
+
+[testenv:pipdeptree]
+deps =
+    pipdeptree
+commands = pipdeptree -w fail
+
+[testenv:pipdeptree-requirements]
+deps =
+     -rrequirements/base.txt
+    pipdeptree
+commands = pipdeptree -w fail
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
Support versions before and after 2 of the XBlock API.

Distinguish using the following logic:

* When using a Python version prior to 3.9, assume we need the pre-2
  API.
* For later Python versions, assume the latest API.

This way, we get the correct dependencies installed for Redwood (which
uses Python 3.11) and earlier releases (which use 3.8).