### PR TITLE
Bump version: 1.6.0 → 2.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 1.6.0
+current_version = 2.0.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<rc>\d+))?
 serialize = 
 	{major}.{minor}.{patch}rc{rc}

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ and displays it as HTML.
 You may install the markdown-xblock to your Tutor environment by adding it to the `OPENEDX_EXTRA_PIP_REQUIREMENTS` list in `config.yml`:
 ```
 OPENEDX_EXTRA_PIP_REQUIREMENTS:
-- markdown-xblock==1.6.0
+- markdown-xblock==2.0.0
 ```
 
 Or, if you prefer to install directly from Git:
 ```
 OPENEDX_EXTRA_PIP_REQUIREMENTS:
-- git+https://github.com/citynetwork/markdown-xblock.git@v1.6.0
+- git+https://github.com/citynetwork/markdown-xblock.git@v2.0.0
 ```
 For additional information, please refer to the official [documentation](https://docs.tutor.edly.io/configuration.html#open-edx-customisation).
 


### PR DESCRIPTION
With dropping the support for Python 3.8 and with that for releases earlier than Redwood we need to bump the major version.