### PR TITLE
Move to the modern pyproject.toml settings file

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -56,12 +56,12 @@ Push these two commits (the one for the changelog, and the version
 bump) to `origin`. Make sure you push the `v<num>` tag to `origin` as
 well.
 
-Then, build a new `sdist` package, and [upload it to
+Then, build a new `sdist` package (with [build](https://pypi.org/project/build/)), and [upload it to
 PyPI](https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives)
 (with [twine](https://packaging.python.org/key_projects/#twine)):
 
 ```bash
 rm dist/* -f
-./setup.py sdist
+python -m build --sdist
 twine upload dist/*
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["setuptools>=61.0", "setuptools-scm[toml]>=7"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "markdown-xblock"
+dynamic = ["version"]
+dependencies = [
+    "XBlock>=5.2,<5.3",
+    "markdown2>=2.3.9",
+    "Pygments>=2.0.1",
+    "lxml-html-clean>=0.4.3"
+]
+requires-python = ">=3.11"
+description = "Markdown XBlock provides editing course content in Markdown."
+readme = {file = "README.md", content-type = "text/markdown"}
+license = "AGPL-3.0-only"
+license-files = ["LICENSE"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Framework :: Django",
+    "Intended Audience :: Education",
+    "Topic :: Education :: Computer Aided Instruction (CAI)",
+    "Topic :: Education",
+]
+
+[project.urls]
+Repository = "https://github.com/cleura/markdown-xblock"
+
+[project.entry-points."xblock.v1"]
+markdown = "markdown_xblock:MarkdownXBlock"
+
+[tool.setuptools_scm]
+
+[tool.setuptools]
+packages = { find = {} }
+
+[tool.setuptools.package-data]
+markdown_xblock = [
+  "static/**",
+  "public/**"
+]

--- a/setup.py
+++ b/setup.py
@@ -1,59 +1,6 @@
-"""Setup for Markdown XBlock."""
-
-import os
+#!/usr/bin/env python
+"""Setup for hastexo XBlock."""
 
 from setuptools import setup
 
-
-def package_data(pkg, roots):
-    """Generic function to find package_data.
-
-    All of the files under each of the `roots` will be declared as package
-    data for package `pkg`.
-
-    """
-    data = []
-    for root in roots:
-        for dirname, _, files in os.walk(os.path.join(pkg, root)):
-            for fname in files:
-                data.append(os.path.relpath(os.path.join(dirname, fname), pkg))
-
-    return {pkg: data}
-
-
-setup(
-    name='markdown-xblock',
-    use_scm_version=True,
-    description='Markdown XBlock provides editing course content in Markdown.',
-    long_description=open('README.md').read(),
-    long_description_content_type='text/markdown',
-    url='https://github.com/cleura/markdown-xblock',
-    license='AGPL-3.0',
-    classifiers=[
-        'Development Status :: 4 - Beta',
-        'Framework :: Django',
-        'Intended Audience :: Education',
-        'License :: OSI Approved :: GNU Affero General Public License v3',
-        'Topic :: Education :: Computer Aided Instruction (CAI)',
-        'Topic :: Education',
-    ],
-    packages=[
-        'markdown_xblock',
-    ],
-    python_requires='>=3.11',
-    install_requires=[
-        'XBlock>=5.2,<5.3',
-        'markdown2>=2.3.9',
-        'Pygments>=2.0.1',
-        'lxml-html-clean>=0.4.3'
-    ],
-    setup_requires=[
-        'setuptools-scm',
-    ],
-    entry_points={
-        'xblock.v1': [
-            'markdown = markdown_xblock:MarkdownXBlock'
-        ]
-    },
-    package_data=package_data("markdown_xblock", ["static", "public"]),
-)
+setup()


### PR DESCRIPTION
Using the pyproject.toml file is strongly recommended by the Python community and will help us move away from using the deprecated `python setup.py sdist` build command.
(https://packaging.python.org/en/latest/discussions/setup-py-deprecated/)

Add the pyproject.toml file and move the content onver from setup.py file.